### PR TITLE
Display landing page when blog slug is missing

### DIFF
--- a/cms_blogger/urls.py
+++ b/cms_blogger/urls.py
@@ -5,5 +5,5 @@ urlpatterns = patterns('cms_blogger.views',
     url(r'blogs/(?P<blog_slug>.+)/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d+)/(?P<entry_slug>.+)/$', 'entry_page'),
     url(r'blogs/(?P<blog_slug>.+)/category/(?P<slug>.+)/$', 'category_page'),
     url(r'blogs/(?P<blog_slug>.+)/(?P<slug>.+)/$', 'entry_or_bio_page'),
-    url(r'blogs/(?P<blog_slug>.+)/$', 'landing_page'),
+    url(r'blogs(?:/(?P<blog_slug>.+))?/$', 'landing_page'),
 )

--- a/cms_blogger/views.py
+++ b/cms_blogger/views.py
@@ -74,13 +74,24 @@ def _paginate_entries_on_blog(request, entries, blog):
 
 
 def landing_page(request, blog_slug):
-    blog = get_object_or_404(
-        Blog, slug=blog_slug, site=Site.objects.get_current())
+    if not blog_slug:
+        site = Site.objects.get_current()
+        if Blog.objects.filter(site=site).count() == 1:
+            blog = Blog.objects.filter(site=site)[0]
+        else:
+            return HttpResponseNotFound(
+                "<h1>The blog slug is missing from the URL")
+    else:
+        blog = get_object_or_404(
+            Blog, slug=blog_slug, site=Site.objects.get_current())
+
     layout = blog.get_layout()
+
     if not layout:
         return HttpResponseNotFound(
             "<h1>This Blog Landing Page does not have a "
             "layout to render.</h1>")
+
     extra_params, entries = _paginate_entries_on_blog(
         request, blog.get_entries(), blog)
     context = RequestContext(request)


### PR DESCRIPTION
When a site has a single blog and no blogslug is specified in the url
then dispaly the landing page of that blog.
